### PR TITLE
fix: add missing commonjs proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "author": "Tobias Koppers @sokra",
   "description": "val loader module for webpack",
-  "main": "dist/index.js",
+  "main": "dist/cjs.js",
   "scripts": {
     "test": "jest",
     "posttest": "npm run lint",

--- a/src/cjs.js
+++ b/src/cjs.js
@@ -1,0 +1,1 @@
+module.exports = require('./index').default;


### PR DESCRIPTION
<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->

Adds the missing `cjs.js` file that handles the `.default` issue and changes the main prop in the `package.json`

Closes #13 