### PR TITLE
feat: add support for `contextDependencies` in the `{Object}` interface (`options.contextDependencies`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Property | Type | Description
 `sourceMap` | [`SourceMap`](https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k/edit) | **Optional**. Will be passed to the next loader or to webpack.
 `ast` | `any` | **Optional**. An [Abstract Syntax Tree](https://en.wikipedia.org/wiki/Abstract_syntax_tree) that will be passed to the next loader. Useful to speed up the build time if the next loader uses the same AST.
 `dependencies` | `Array<string>` | **Default: `[]`**. An array of absolute, native paths to file dependencies that need to be watched for changes.
+`contextDependencies` | `Array<string>` | **Default: `[]`**. An array of absolute, native paths to directory dependencies that need to be watched for changes.
 `cacheable` | `boolean` | **Default: `false`**. Flag whether the code can be re-used in watch mode if none of the `dependencies` have changed.
 
 ### Loader Options

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,10 @@ function processResult(loaderContext, result) {
 
   (result.dependencies || [])
     .forEach(dep => loaderContext.addDependency(dep));
+
+  (result.contextDependencies || [])
+    .forEach(dep => loaderContext.addContextDependency(dep));
+
   // Defaults to false which is a good default here because we assume that
   // results tend to be not cacheable when this loader is necessary
   loaderContext.cacheable(Boolean(result.cacheable));

--- a/test/fixtures/dependencies.js
+++ b/test/fixtures/dependencies.js
@@ -4,6 +4,9 @@ function dependencies() {
       require.resolve('./args.js'),
       require.resolve('./simple.js'),
     ],
+    contextDependencies: [
+      __dirname,
+    ],
     code: '',
   };
 }


### PR DESCRIPTION
This change adds support for declaring directories as dependencies by using `contextDependencies` in object interface returned by the generator function.

Background: I've been using val-loader to generate modules based on some configuration files which are grouped in a single directory. In my generator function, I traverse that directory and parse all found configuration files adding them to the dependencies array. Problem is that in watch mode if a new file is added in that directory it will not be picked up by the webpack and I need to stop it and rerun it again.

Regarding the tests, I have simply added `contextDependencies` to `test/fixtures/depenndencies.js` in order to make codecov happy :)
If I need to do something more please let me know.

Hopefully, you will find this addition welcome :)