### PR TITLE
make loader Webpack@5 compatible

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import path from 'path';
+import Module from 'module';
 import loaderUtils from 'loader-utils';
 
 function rel(p) {
@@ -29,7 +30,13 @@ function processResult(loaderContext, result) {
 
 function valLoader(content) {
   const options = loaderUtils.getOptions(this);
-  const exports = this.exec(content, this.resource);
+
+  const module = new Module(this.resource, this);
+  module.paths = Module._nodeModulePaths(this.context); // eslint-disable-line no-underscore-dangle
+  module.filename = this.resource;
+  module._compile(content, this.resource);  // eslint-disable-line no-underscore-dangle
+
+  const { exports } = module;
   const func = (exports && exports.default) ? exports.default : exports;
 
   if (typeof func !== 'function') {


### PR DESCRIPTION
https://github.com/webpack/webpack.js.org/issues/1268#issuecomment-313513988

<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->
Webpack 5 removed this.exec in loader context

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
