### PR TITLE
docs(readme): use a consistent filename in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ module.exports = {
 
 ```js
 // src/entry.js
-const answer = require('test-file');
+const answer = require('target-file');
 ```
 
 And run `webpack` via your preferred method.


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [x] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

At first the example was confusing, doing some _magic_ with imports.
Until I figured out that there is just a typo in the filename.

### Breaking Changes

### Additional Info
