### PR TITLE
feat: pass `loaderContext` as 2nd parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ the loader changes a module from code to a result.
 Another way to view `val-loader`, is that it allows a user a way to make their
 own custom loader logic, without having to write a custom loader.
 
+The target module is called with two arguments: `(options, loaderContext)`
+
+- `options`: The loader options (for instance provided in the webpack config. See the [example](#examples) below).
+- `loaderContext`: [The loader context](https://webpack.js.org/api/loaders/#the-loader-context).
+
 ## Getting Started
 
 To begin, you'll need to install `val-loader`:
@@ -34,7 +39,7 @@ Then add the loader to your `webpack` config. For example:
 **target-file.js**
 
 ```js
-module.exports = () => {
+module.exports = (options, loaderContext) => {
   return { code: 'module.exports = 42;' };
 };
 ```
@@ -104,6 +109,8 @@ Default: `[]`
 An array of absolute, native paths to file dependencies that should be watched
 by webpack for changes.
 
+Dependencies can also be added using [`loaderContext.addDependency(file: string)`](https://webpack.js.org/api/loaders/#thisadddependency).
+
 ### `contextDependencies`
 
 Type: `Array[String]`
@@ -111,6 +118,8 @@ Default: `[]`
 
 An array of absolute, native paths to directory dependencies that should be
 watched by webpack for changes.
+
+Context dependencies can also be added using [`loaderContext.addContextDependency(directory: string)`](https://webpack.js.org/api/loaders/#thisaddcontextdependency).
 
 ### `cacheable`
 

--- a/src/index.js
+++ b/src/index.js
@@ -93,7 +93,7 @@ export default function loader(content) {
   let result;
 
   try {
-    result = func(options);
+    result = func(options, this);
   } catch (error) {
     throw new Error(`Module "${this.resource}" throw error: ${error}`);
   }

--- a/test/__snapshots__/loader.test.js.snap
+++ b/test/__snapshots__/loader.test.js.snap
@@ -1,5 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`loader should allow adding dependencies and contextDependencies via loader context: errors 1`] = `Array []`;
+
+exports[`loader should allow adding dependencies and contextDependencies via loader context: result 1`] = `
+"{
+  \\"content\\": \\"module.exports = \\\\\\"hello world\\\\\\";\\",
+  \\"map\\": null,
+  \\"meta\\": null,
+  \\"dependencies\\": [
+    \\"test/fixtures/dependencies-via-context.js\\",
+    \\"test/fixtures/args.js\\",
+    \\"test/fixtures/simple.js\\"
+  ],
+  \\"contextDependencies\\": [
+    \\"test/fixtures\\"
+  ]
+}"
+`;
+
+exports[`loader should allow adding dependencies and contextDependencies via loader context: warnings 1`] = `Array []`;
+
 exports[`loader should call the function with the loader options: errors 1`] = `Array []`;
 
 exports[`loader should call the function with the loader options: result 1`] = `
@@ -100,6 +120,31 @@ exports[`loader should has module.parent: result 1`] = `
 `;
 
 exports[`loader should has module.parent: warnings 1`] = `Array []`;
+
+exports[`loader should keep dependencies if errors are emitted: errors 1`] = `
+Array [
+  "ModuleError: Module Error (from /src/index.js):
+(Emitted value instead of an instance of Error) Error: Calling the function failed",
+]
+`;
+
+exports[`loader should keep dependencies if errors are emitted: result 1`] = `
+"{
+  \\"content\\": \\"module.exports = \\\\\\"hello world\\\\\\";\\",
+  \\"map\\": null,
+  \\"meta\\": null,
+  \\"dependencies\\": [
+    \\"test/fixtures/error-emitted-with-dependencies.js\\",
+    \\"test/fixtures/args.js\\",
+    \\"test/fixtures/simple.js\\"
+  ],
+  \\"contextDependencies\\": [
+    \\"test/fixtures\\"
+  ]
+}"
+`;
+
+exports[`loader should keep dependencies if errors are emitted: warnings 1`] = `Array []`;
 
 exports[`loader should not swallow function call errors (async): errors 1`] = `
 Array [

--- a/test/fixtures/args.js
+++ b/test/fixtures/args.js
@@ -1,9 +1,8 @@
-function args(...args) {
+function args(options) {
   return {
     code: 'module.exports = "hello world";',
-    // We can't use rest parameters here because this code is not touched by babel
     // We use the ast property because it is not validated
-    ast: args, // eslint-disable-line prefer-rest-params
+    ast: [options],
   };
 }
 

--- a/test/fixtures/dependencies-via-context.js
+++ b/test/fixtures/dependencies-via-context.js
@@ -1,0 +1,11 @@
+function dependencies(options, loaderContext) {
+  loaderContext.addDependency(require.resolve('./args.js'));
+  loaderContext.addDependency(require.resolve('./simple.js'));
+  loaderContext.addContextDependency(__dirname);
+
+  return {
+    code: 'module.exports = "hello world";',
+  };
+}
+
+module.exports = dependencies;

--- a/test/fixtures/error-emitted-with-dependencies.js
+++ b/test/fixtures/error-emitted-with-dependencies.js
@@ -1,0 +1,14 @@
+function errorEmittedWithDependencies(options, loaderOptions) {
+  loaderOptions.emitError(new Error('Calling the function failed'));
+
+  return {
+    dependencies: [
+      require.resolve('./args.js'),
+      require.resolve('./simple.js'),
+    ],
+    contextDependencies: [__dirname],
+    code: 'module.exports = "hello world";',
+  };
+}
+
+module.exports = errorEmittedWithDependencies;

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -119,6 +119,19 @@ describe('loader', () => {
     expect(normalizeErrors(stats.compilation.errors)).toMatchSnapshot('errors');
   });
 
+  it('should allow adding dependencies and contextDependencies via loader context', async () => {
+    const compiler = getCompiler('dependencies-via-context.js');
+    const stats = await compile(compiler);
+
+    expect(readAsset('val-loader.js', compiler, stats)).toMatchSnapshot(
+      'result'
+    );
+    expect(normalizeErrors(stats.compilation.warnings)).toMatchSnapshot(
+      'warnings'
+    );
+    expect(normalizeErrors(stats.compilation.errors)).toMatchSnapshot('errors');
+  });
+
   it('should work the same if a promise is returned', async () => {
     const compiler = getCompiler('promise.js');
     const stats = await compile(compiler);
@@ -160,6 +173,19 @@ describe('loader', () => {
 
   it('should has module.parent', async () => {
     const compiler = getCompiler('module-parent.js');
+    const stats = await compile(compiler);
+
+    expect(readAsset('val-loader.js', compiler, stats)).toMatchSnapshot(
+      'result'
+    );
+    expect(normalizeErrors(stats.compilation.warnings)).toMatchSnapshot(
+      'warnings'
+    );
+    expect(normalizeErrors(stats.compilation.errors)).toMatchSnapshot('errors');
+  });
+
+  it('should keep dependencies if errors are emitted', async () => {
+    const compiler = getCompiler('error-emitted-with-dependencies.js');
     const stats = await compile(compiler);
 
     expect(readAsset('val-loader.js', compiler, stats)).toMatchSnapshot(


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

fixes #46 

### Breaking Changes

Shouldn't be any (I wouldn't consider the change I had to do in `test/args.js` a breaking change).

### Additional Information

The tests are covering the two exact use-cases I mentioned in #46, i.e. it does not check that it is the actual loader context, but rather uses it. Hope that's good enough testing for this.