### PR TITLE
fix: strip webpack-specific parts from filename

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,8 @@ function execute(code, loaderContext) {
 
   // eslint-disable-next-line no-underscore-dangle
   module.paths = Module._nodeModulePaths(loaderContext.context);
-  module.filename = loaderContext.resource;
+  // Use the path without webpack-specific parts (`resourceQuery` or `resourceFragment`)
+  module.filename = loaderContext.resourcePath;
 
   // eslint-disable-next-line no-underscore-dangle
   module._compile(code, loaderContext.resource);


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**: #121
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Use `resourceQuery` or `resourceFragment` with cache

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info

It's hard to write tests for this case, the error is not from compilation.
